### PR TITLE
Overwrite built-in echo so that it can't takes any options/operands

### DIFF
--- a/bin/ceor.sh
+++ b/bin/ceor.sh
@@ -43,6 +43,11 @@
 ##############################################################################
 # Functions.
 ##############################################################################
+echo () {
+  # Overwrite built-in echo so that it can't takes any options/operands
+  printf "%s\n" "$*"
+}
+##############################################################################
 parse_conf() {			# parse configuration files.
 
   # Define Variables.


### PR DESCRIPTION
For historical reasons, several popular implementations of echo(1) are
completely incompatible with each other.

For example:
    * `echo "-e"` prints a blank line in Bash
    * `/bin/echo "foo\c"` suppresses a trailing newline in FreeBSD

POSIX does not guarantee outputs caused by these options/operands and
that's almost enough to scare me using echo(1) in shell scripts,
especially against variables provided by conf files.

This patch will overwrite built-in echo with printf(1) in order to
nullify these "funky" features implemented on echo(1).

https://ja.stackoverflow.com/a/60057/62 (Japanese explanation)
https://pubs.opengroup.org/onlinepubs/009604599/utilities/echo.html