### PR TITLE
Don't use `which` command in bourne like shells

### DIFF
--- a/bin/ceor.sh
+++ b/bin/ceor.sh
@@ -212,10 +212,8 @@ __EXPORT_ENV_NAME="${__EXPORT_ENV_NAME} __TMPDIR"
 #####
 
 cat << "__END__" >> ${__TMPDIR}/module.sh
-if ! command -v sudo >/dev/null 2>&1; then
-  echo "Do not have sudo!. exit"
-  exit 1
-fi
+__SUDO=`command -v sudo`
+[ -z "${__SUDO}" ] && echo "Do not have sudo!. exit" && exit 1
 __END__
 
 for __i in ${MODULE}; do

--- a/bin/ceor.sh
+++ b/bin/ceor.sh
@@ -212,8 +212,10 @@ __EXPORT_ENV_NAME="${__EXPORT_ENV_NAME} __TMPDIR"
 #####
 
 cat << "__END__" >> ${__TMPDIR}/module.sh
-__SUDO=`which sudo`
-[ -z "${__SUDO}" ] && echo "Do not have sudo!. exit" && exit 1
+if ! command -v sudo >/dev/null 2>&1; then
+  echo "Do not have sudo!. exit"
+  exit 1
+fi
 __END__
 
 for __i in ${MODULE}; do


### PR DESCRIPTION
which(1) was originally introduced by csh, many of today's
implementations still read ~/.cshrc in order to resolve $PATH and
aliases.

AFAIK, Gentoo Linux Handbook has mentioned about this behaviour and they
would rather use `type -P` bash built-in for this purpose about a decade
ago. (Can't find the references though)

Now we have POSIX `command`, the most portable way, to do the job.

This patch also removes variable `$__SUDO` which seems unused.

https://unix.stackexchange.com/a/85250/53620
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html